### PR TITLE
docs: correct identity path in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,18 @@
 https://armada-alliance.com
 
 ## Our Mission
+
 - The Armada alliance was formed in efforts to build a community of decentralized, low-cost, and energy-efficient stake pool operations on Cardano. All Stake Pools that are apart of this alliance run on either Raspberry Pis exclusively or low power consuming ARM-based machines.
 
 ## How to add your pool to the website
 
 1. Fork this repo with your GitHub account
 
-2. Add a file named `<IDENTITY_ID>.md` for every stake pool operator of your stake pool inside https://github.com/armada-alliance/armada-alliance/tree/main/services/website/content/en/stake-pools
+2. Add a file named `<IDENTITY_ID>.md` for every stake pool operator of your stake pool inside https://github.com/armada-alliance/armada-alliance/tree/main/services/website/content/en/identities
 
 3. Add a file named <POOL_ID>.md for your pool inside https://github.com/armada-alliance/armada-alliance/tree/main/services/website/content/en/stake-pools
 
-3. Head back to the armada-alliance github and submit a pull request to add your pool to the website
+4. Head back to the armada-alliance github and submit a pull request to add your pool to the website
 
 #### Here is an example of an identity md file.
 
@@ -46,13 +47,12 @@ https://adapulse.io/arming-cardano-an-ecosystem-for-raspberry-pi-stakepool-opera
 template: PoolDetailPage
 ticker: PIADA
 memberSince: 2021-04-18 # the date on which you joined the alliance
-identities: 
-    - id: tony-piada
-      role: spo
-    - id: wael-ivie
-      role: spo
+identities:
+  - id: tony-piada
+    role: spo
+  - id: wael-ivie
+    role: spo
 ---
 ```
 
 Please join our alliance's telegram channel https://t.me/armada_alli because this will be the main place we discuss and vote on the future of our alliance. Thank You for Joining the Armada Alliance :smile:
-


### PR DESCRIPTION
This PR corrects the path for adding `identities` to the site. It also fixes the numbering in the bullets and does some basic VS Code markdown linting.