### PR TITLE
Update 7e45a7e6ab3afcf99120e97aedf84e706e43d829ddc610ad667a85a3.md

### DIFF
--- a/services/website/content/en/stake-pools/7e45a7e6ab3afcf99120e97aedf84e706e43d829ddc610ad667a85a3.md
+++ b/services/website/content/en/stake-pools/7e45a7e6ab3afcf99120e97aedf84e706e43d829ddc610ad667a85a3.md
@@ -43,11 +43,12 @@ Keep running the stakepool and focus on learning Plutus. I publish pool status e
 I only update about the pool, cardano learnings and also AI & Blockchain.
 I am currently building DeepChainAda using Plutus on Cardano.
 The Idea is to connect this DeepChainAda to Idris which is the AI domain specific language that SingularityNet is planning to adopt.
-======================================================
+
+
 AI Agent -> AI DSL -> Idris => Plutus -> Haskell
-======================================================
+
 SingularityNet=> DeepchainSC on Cardano 
-=======================================================
+
 
 ## Why Stake with PGWAD
 PGWAD is investing in the future. Many things in Future like smart grid (for electricity distribution) will need the concept of Privacy-preserving and Auditable learning. So if you are intersted to understand how this area evolves then please follow us and if you can delegate to this pool please do. In Cardano the pool rewards are consistant when delegation is at 10Million or above. Until then the rewards from this pool will be sporadic (depending on stake in pool). We plan to keep investing in this pool (increase pledge, Hw etc) and also the task of AI+Blockchain.  


### PR DESCRIPTION
Fixed a problem "H1 should not be used, use H2 instead"


# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have checked my pool's registration status using https://pool.vet and have passed all checks.
- [ ] I have create an <IDENTITY_ID>.md for every stake pool operator of my pool file inside https://github.com/armada-alliance/armada-alliance/tree/main/services/website/content/en/stake-pools
- [ ] I have create a <POOL_ID>.md file for my pool inside https://github.com/armada-alliance/armada-alliance/tree/main/services/website/content/en/identities
- [ ] I have included my pool's ID in my <POOL_TICKER>.json file
- [ ] I have included my personal telegram handle in my <IDENTITY_ID>.md file